### PR TITLE
Enable multiple queue creation with own metric alert rules

### DIFF
--- a/action-group/outputs.tf
+++ b/action-group/outputs.tf
@@ -1,4 +1,4 @@
 output "action_group_id" {
-  value = azurerm_monitor_action_group.monitor-action-group.id
+  value       = azurerm_monitor_action_group.monitor-action-group.id
   description = "The ID of the Action Group."
 }

--- a/main.tf
+++ b/main.tf
@@ -27,10 +27,12 @@ module "servicebus-namespace" {
 }
 
 module "servicebus-queue" {
+  for_each = toset(var.queue_names)
+
   source = "./servicebus-queue"
-  queue_name = var.queue_name
+  queue_name = each.key
   namespace_id = module.servicebus-namespace.namespace_id
-  dead_lettering_enabled = var.dead_lettering_enabled
+  dead_lettering_enabled = var.dead_lettering_enabled[each.value] == true ? true : false
 }
 
 module "action-group" {

--- a/main.tf
+++ b/main.tf
@@ -47,16 +47,17 @@ module "metric-alert" {
   source = "./metric-alert"
   for_each = var.alert_rule
 
-  action_group_id = module.action-group.action_group_id
   alert_name = each.value.alert_name
+  dimension_operator = each.value.dimension_operator
+  dimension_values = each.value.queue_name_list
   message_threshold = each.value.threshold
+  metric_name = each.value.metric_name
+
+  action_group_id = module.action-group.action_group_id
   namespace_id = module.servicebus-namespace.namespace_id
   resource_group_name = module.resource-group.resource_group_name
   aggregation = var.metric_aggregation
-  metric_name = each.value.metric_name
   metric_namespace = var.metric_namespace
   operator = var.metric_operator
   dimension_name = var.dimension_name
-  dimension_operator = var.dimension_operator
-  dimension_values = each.value.queue_name_list
 }

--- a/main.tf
+++ b/main.tf
@@ -13,51 +13,51 @@ provider "azurerm" {
 }
 
 module "resource-group" {
-  source = "./resource-group"
+  source                  = "./resource-group"
   resource_group_location = var.resouce_group_location
-  resource_group_name = var.resource_group_name
+  resource_group_name     = var.resource_group_name
 }
 
 module "servicebus-namespace" {
-  source = "./servicebus-namespace"
-  namespace_name = var.namespace_name
-  resource_group_name = module.resource-group.resource_group_name
+  source                  = "./servicebus-namespace"
+  namespace_name          = var.namespace_name
+  resource_group_name     = module.resource-group.resource_group_name
   resource_group_location = module.resource-group.resource_group_location
-  sku = var.namespace_sku
+  sku                     = var.namespace_sku
 }
 
 module "servicebus-queue" {
-  source = "./servicebus-queue"
+  source   = "./servicebus-queue"
   for_each = var.queue_name_and_dlq
 
   dead_lettering_enabled = each.value
-  queue_name = each.key
+  queue_name             = each.key
 
   namespace_id = module.servicebus-namespace.namespace_id
 }
 
 module "action-group" {
-  source = "./action-group"
+  source              = "./action-group"
   resource_group_name = module.resource-group.resource_group_name
-  action_group_name = var.action_group_name
-  short_name = var.action_group_short_name
+  action_group_name   = var.action_group_name
+  short_name          = var.action_group_short_name
 }
 
 module "metric-alert" {
-  source = "./metric-alert"
+  source   = "./metric-alert"
   for_each = var.alert_rule
 
-  alert_name = each.value.alert_name
+  alert_name         = each.value.alert_name
   dimension_operator = each.value.dimension_operator
-  dimension_values = each.value.queue_name_list
-  message_threshold = each.value.threshold
-  metric_name = each.value.metric_name
+  dimension_values   = each.value.queue_name_list
+  message_threshold  = each.value.threshold
+  metric_name        = each.value.metric_name
 
-  action_group_id = module.action-group.action_group_id
-  namespace_id = module.servicebus-namespace.namespace_id
+  action_group_id     = module.action-group.action_group_id
+  namespace_id        = module.servicebus-namespace.namespace_id
   resource_group_name = module.resource-group.resource_group_name
-  aggregation = var.metric_aggregation
-  metric_namespace = var.metric_namespace
-  operator = var.metric_operator
-  dimension_name = var.dimension_name
+  aggregation         = var.metric_aggregation
+  metric_namespace    = var.metric_namespace
+  operator            = var.metric_operator
+  dimension_name      = var.dimension_name
 }

--- a/main.tf
+++ b/main.tf
@@ -28,11 +28,12 @@ module "servicebus-namespace" {
 
 module "servicebus-queue" {
   source = "./servicebus-queue"
-  for_each = toset(var.queue_names)
+  for_each = var.queue_name_and_dlq
 
+  dead_lettering_enabled = each.value
   queue_name = each.key
+
   namespace_id = module.servicebus-namespace.namespace_id
-  dead_lettering_enabled = var.dead_lettering_enabled[each.value] == true ? true : false
 }
 
 module "action-group" {

--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,9 @@ module "servicebus-namespace" {
 }
 
 module "servicebus-queue" {
+  source = "./servicebus-queue"
   for_each = toset(var.queue_names)
 
-  source = "./servicebus-queue"
   queue_name = each.key
   namespace_id = module.servicebus-namespace.namespace_id
   dead_lettering_enabled = var.dead_lettering_enabled[each.value] == true ? true : false
@@ -44,13 +44,18 @@ module "action-group" {
 
 module "metric-alert" {
   source = "./metric-alert"
+  for_each = var.alert_rule
+
   action_group_id = module.action-group.action_group_id
-  alert_name = var.alert_name
-  message_threshold = var.alert_message_threshold
+  alert_name = each.value.alert_name
+  message_threshold = each.value.threshold
   namespace_id = module.servicebus-namespace.namespace_id
   resource_group_name = module.resource-group.resource_group_name
   aggregation = var.metric_aggregation
-  metric_name = var.metric_name
+  metric_name = each.value.metric_name
   metric_namespace = var.metric_namespace
   operator = var.metric_operator
+  dimension_name = var.dimension_name
+  dimension_operator = var.dimension_operator
+  dimension_values = each.value.queue_name_list
 }

--- a/metric-alert/main.tf
+++ b/metric-alert/main.tf
@@ -9,6 +9,12 @@ resource "azurerm_monitor_metric_alert" "metric-alert" {
     metric_namespace = var.metric_namespace
     operator         = var.operator
     threshold        = var.message_threshold
+
+    dimension {
+      name     = var.dimension_name
+      operator = var.dimension_operator
+      values   = var.dimension_values
+    }
   }
 
   action {

--- a/metric-alert/variables.tf
+++ b/metric-alert/variables.tf
@@ -25,3 +25,13 @@ variable "metric_namespace" {
 variable "operator" {
   description = "The operator applied to the threshold to trigger an alert."
 }
+variable "dimension_name" {
+  description = "The dimension name."
+}
+variable "dimension_operator" {
+  description = "The operator applied to the dimension."
+}
+variable "dimension_values" {
+  description = "A list describing the dimension values."
+  type = list(string)
+}

--- a/metric-alert/variables.tf
+++ b/metric-alert/variables.tf
@@ -33,5 +33,5 @@ variable "dimension_operator" {
 }
 variable "dimension_values" {
   description = "A list describing the dimension values."
-  type = list(string)
+  type        = list(string)
 }

--- a/resource-group/main.tf
+++ b/resource-group/main.tf
@@ -2,3 +2,4 @@ resource "azurerm_resource_group" "rm" {
   location = var.resource_group_location
   name     = var.resource_group_name
 }
+

--- a/resource-group/outputs.tf
+++ b/resource-group/outputs.tf
@@ -1,9 +1,9 @@
 output "resource_group_location" {
-  value = azurerm_resource_group.rm.location
+  value       = azurerm_resource_group.rm.location
   description = "The location of the Resource Group."
 }
 output "resource_group_name" {
-  value = azurerm_resource_group.rm.name
+  value       = azurerm_resource_group.rm.name
   description = "The name of the Resource Group."
 }
 

--- a/servicebus-namespace/outputs.tf
+++ b/servicebus-namespace/outputs.tf
@@ -1,4 +1,4 @@
 output "namespace_id" {
-  value = azurerm_servicebus_namespace.ns.id
+  value       = azurerm_servicebus_namespace.ns.id
   description = "The ID of the ServiceBus Namespace."
 }

--- a/servicebus-queue/main.tf
+++ b/servicebus-queue/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_servicebus_queue" "queue" {
-  name         = var.queue_name
-  namespace_id = var.namespace_id
+  name                                 = var.queue_name
+  namespace_id                         = var.namespace_id
   dead_lettering_on_message_expiration = var.dead_lettering_enabled
 }

--- a/servicebus-queue/outputs.tf
+++ b/servicebus-queue/outputs.tf
@@ -1,4 +1,0 @@
-output "queue_id" {
-  value = azurerm_servicebus_queue.queue.id
-  description = "The ID of the created ServiceBus Queue."
-}

--- a/variables.tf
+++ b/variables.tf
@@ -17,14 +17,19 @@ variable "namespace_sku" {
   description = "The Stock Keeping Unit Tier of the ServiceBus Namespace."
 }
 # ServiceBus Queue
-variable "queue_name" {
-  default = "queue1"
-  description = "The name of the ServiceBus Queue."
+variable "queue_names" {
+  default = ["queue1", "queue2"]
+  description = "List of names of the ServiceBus Queues."
+  type = list(string)
 }
 # Dead Letter Queue
 variable "dead_lettering_enabled" {
-  default = false
-  description = "Whether or not this queue has dead letter support when a message expires."
+  default = {
+    "queue1" = false
+    "queue2" = true
+  }
+  description = "Map to describe which queue has dead letter support when a message expires. Correlates with queue_names."
+  type = map(bool)
 }
 # Action Group
 variable "action_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,20 +16,14 @@ variable "namespace_sku" {
   default     = "Standard"
   description = "The Stock Keeping Unit Tier of the ServiceBus Namespace."
 }
-# ServiceBus Queue
-variable "queue_names" {
-  default     = ["queue1"]
-  description = "List of names of the ServiceBus Queues."
-  type        = list(string)
-}
-# Dead Letter Queue
-variable "dead_lettering_enabled" {
+# ServiceBus Queue & Dead Letter Queue
+variable "queue_name_and_dlq" {
   default = {
     "queue1" = false
     "queue2" = true
   }
-  description = "Map to describe which queue has dead letter support when a message expires. Correlates with queue_names."
-  type        = map(bool)
+  description = "Map Service Bus Queue names (string) as key and the respective dead_lettering_enabled value (bool) as value."
+  type = map(bool)
 }
 # Action Group
 variable "action_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,6 @@ variable "namespace_sku" {
 variable "queue_name_and_dlq" {
   default = {
     "queue1" = false
-    "queue2" = true
   }
   description = "Map Service Bus Queue names (string) as key and the respective dead_lettering_enabled value (bool) as value."
   type        = map(bool)
@@ -51,13 +50,6 @@ variable "alert_rule" {
       threshold          = 10
       dimension_operator = "Include"
       queue_name_list    = ["queue1"]
-    }
-    rule2 = {
-      alert_name         = "testAlert2"
-      metric_name        = "DeadletteredMessages"
-      threshold          = 0
-      dimension_operator = "Include"
-      queue_name_list    = ["queue2"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "queue_name_and_dlq" {
     "queue2" = true
   }
   description = "Map Service Bus Queue names (string) as key and the respective dead_lettering_enabled value (bool) as value."
-  type = map(bool)
+  type        = map(bool)
 }
 # Action Group
 variable "action_group_name" {
@@ -38,26 +38,26 @@ variable "action_group_short_name" {
 variable "alert_rule" {
   description = "Map of alert rules. Describes the desired alert name, metric (by name), threshold, and list of queues to monitor."
   type        = map(object({
-    alert_name = string
-    metric_name = string
-    threshold   = number
+    alert_name         = string
+    metric_name        = string
+    threshold          = number
     dimension_operator = string
-    queue_name_list  = list(string)
+    queue_name_list    = list(string)
   }))
   default = {
     rule1 = {
-      alert_name = "testAlert"
-      metric_name = "Messages"
-      threshold   = 10
+      alert_name         = "testAlert"
+      metric_name        = "Messages"
+      threshold          = 10
       dimension_operator = "Include"
-      queue_name_list  = ["queue1"]
+      queue_name_list    = ["queue1"]
     }
     rule2 = {
-      alert_name = "testAlert2"
-      metric_name = "DeadletteredMessages"
-      threshold   = 0
+      alert_name         = "testAlert2"
+      metric_name        = "DeadletteredMessages"
+      threshold          = 0
       dimension_operator = "Include"
-      queue_name_list  = ["queue2"]
+      queue_name_list    = ["queue2"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,26 +1,26 @@
 # Resource Group
 variable "resouce_group_location" {
-  default = "Germany West Central"
+  default     = "Germany West Central"
   description = "The location of the Resource Group."
 }
 variable "resource_group_name" {
-  default = "myTFResourceGroup"
+  default     = "myTFResourceGroup"
   description = "The name of the Resource Group."
 }
 # ServiceBus Namespace
 variable "namespace_name" {
-  default = "testns22"
+  default     = "testns22"
   description = "The name of the Azure ServiceBus Namespace."
 }
 variable "namespace_sku" {
-  default = "Standard"
+  default     = "Standard"
   description = "The Stock Keeping Unit Tier of the ServiceBus Namespace."
 }
 # ServiceBus Queue
 variable "queue_names" {
-  default = ["queue1", "queue2"]
+  default     = ["queue1"]
   description = "List of names of the ServiceBus Queues."
-  type = list(string)
+  type        = list(string)
 }
 # Dead Letter Queue
 variable "dead_lettering_enabled" {
@@ -29,40 +29,58 @@ variable "dead_lettering_enabled" {
     "queue2" = true
   }
   description = "Map to describe which queue has dead letter support when a message expires. Correlates with queue_names."
-  type = map(bool)
+  type        = map(bool)
 }
 # Action Group
 variable "action_group_name" {
-  default = "action-group-0"
+  default     = "action-group-0"
   description = "The name of the Action Group"
 }
 variable "action_group_short_name" {
-default = "p0action"
-description = "The short name of the Action Group."
+  default     = "p0action"
+  description = "The short name of the Action Group."
 }
 # Alert
-variable "alert_message_threshold" {
-  default = 10
-  description = "The threshold of total messages which triggers an alert."
+variable "alert_rule" {
+  description = "Map of alert rules. Describes the desired alert name, metric (by name), threshold, and list of queues to monitor."
+  type        = map(object({
+    alert_name = string
+    metric_name = string
+    threshold   = number
+    queue_name_list  = list(string)
+  }))
+  default = {
+    rule1 = {
+      alert_name = "testAlert"
+      metric_name = "Messages"
+      threshold   = 10
+      queue_name_list  = ["queue1"]
+    },
+  }
 }
-variable "alert_name" {
-  default = "alert1"
-  description = "The name of the alert."
+variable "dimension_name" {
+  default     = "EntityName"
+  description = "The dimension name."
+}
+variable "dimension_operator" {
+  default     = "Include"
+  description = "The operator applied to the dimension."
+}
+variable "dimension_values" {
+  default     = ["queue2"]
+  description = "A list describing the dimension values."
+  type        = list(string)
 }
 # Metric for above alert
-variable "metric_name" {
-  default = "Messages"
-  description = "The name of the metric."
-}
 variable "metric_aggregation" {
-  default = "Average"
+  default     = "Average"
   description = "The aggregation type of the metric."
 }
 variable "metric_namespace" {
-  default = "Microsoft.ServiceBus/Namespaces"
+  default     = "Microsoft.ServiceBus/Namespaces"
   description = "The namespace of the metric."
 }
 variable "metric_operator" {
-  default = "GreaterThan"
+  default     = "GreaterThan"
   description = "The operator applied to the threshold to trigger an alert."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,7 @@ variable "alert_rule" {
     alert_name = string
     metric_name = string
     threshold   = number
+    dimension_operator = string
     queue_name_list  = list(string)
   }))
   default = {
@@ -48,22 +49,21 @@ variable "alert_rule" {
       alert_name = "testAlert"
       metric_name = "Messages"
       threshold   = 10
+      dimension_operator = "Include"
       queue_name_list  = ["queue1"]
-    },
+    }
+    rule2 = {
+      alert_name = "testAlert2"
+      metric_name = "DeadletteredMessages"
+      threshold   = 0
+      dimension_operator = "Include"
+      queue_name_list  = ["queue2"]
+    }
   }
 }
 variable "dimension_name" {
   default     = "EntityName"
   description = "The dimension name."
-}
-variable "dimension_operator" {
-  default     = "Include"
-  description = "The operator applied to the dimension."
-}
-variable "dimension_values" {
-  default     = ["queue2"]
-  description = "A list describing the dimension values."
-  type        = list(string)
 }
 # Metric for above alert
 variable "metric_aggregation" {


### PR DESCRIPTION
This PR:

- enables multiple queues to be created with optional DLQs
- enables metric alerts to be assigned to certain queues
   - includes the need to create alert_rule objects to pass to the module
- combines the variables `queue_names` (list of strings) and `DLQ_enabled` (map of bool) into one map(bool) in the below format in order to reduce the amount of times a user needs to manually write the queue name

```
  default = {
    "queue1" = false
    "queue2" = true
  }
```
